### PR TITLE
Relax lower bounds on http types

### DIFF
--- a/prometheus.cabal
+++ b/prometheus.cabal
@@ -77,7 +77,7 @@ library
                , base           >= 4.7  && < 4.10
                , bytestring     >= 0.10 && < 0.11
                , containers     >= 0.5  && < 0.6
-               , http-types     >= 0.9  && < 0.10
+               , http-types     >= 0.8  && < 0.10
                , text           >= 1.2  && < 1.3
                , transformers   >= 0.4  && < 0.6
                , wai            >= 3.2  && < 3.3


### PR DESCRIPTION
Hey @LukeHoersten !

I gave this a go on a project at work and the relaxation of the lower bound for `http-types` doesn't seem to create any trouble. Let me know if you have any strong feelings about that 😉 

Alfredo