### PR TITLE
Fix Histogram 

### DIFF
--- a/src/System/Metrics/Prometheus/Metric/Histogram.hs
+++ b/src/System/Metrics/Prometheus/Metric/Histogram.hs
@@ -52,8 +52,10 @@ observe x = flip atomicModifyIORef' update . unHistogram
 
 
 updateBuckets :: Double -> Buckets -> Buckets
-updateBuckets x = Map.mapWithKey updateBucket
-  where updateBucket key val = bool val (val + 1) (x <= key)
+updateBuckets x bs = updateBucket $ Map.lookupGE x bs
+  where
+    updateBucket Nothing       = bs
+    updateBucket (Just (k, v)) = Map.insert k (v + 1) bs
 
 
 sample :: Histogram -> IO HistogramSample


### PR DESCRIPTION
The current behaviour doesn't make sense, as `observe` will update _all_ buckets with upper bounds greater than the observed value. The correct behaviour is to only update the smallest bucket greater than or equal to the observed value.