### PR TITLE
warning-free GHC 7.8.4 build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.stack-work

--- a/src/System/Metrics/Prometheus/Concurrent/Http.hs
+++ b/src/System/Metrics/Prometheus/Concurrent/Http.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE CPP #-}
 
 module System.Metrics.Prometheus.Concurrent.Http
        ( Path
@@ -8,6 +9,9 @@ module System.Metrics.Prometheus.Concurrent.Http
        )
        where
 
+#if __GLASGOW_HASKELL__ < 710
+import Control.Applicative ((<$>))
+#endif
 import           Control.Monad.IO.Class                         (MonadIO,
                                                                  liftIO)
 import           Data.Text                                      (Text)
@@ -37,7 +41,11 @@ serveHttpTextMetrics :: MonadIO m => Port -> Path -> IO RegistrySample -> m ()
 serveHttpTextMetrics port path = liftIO . run port . prometheusApp path
 
 
+#if __GLASGOW_HASKELL__ < 710
+serveHttpTextMetricsT :: (MonadIO m, Functor m) => Port -> Path -> RegistryT m ()
+#else
 serveHttpTextMetricsT :: MonadIO m => Port -> Path -> RegistryT m ()
+#endif
 serveHttpTextMetricsT port path = liftIO . serveHttpTextMetrics port path =<< sample
 
 

--- a/src/System/Metrics/Prometheus/Concurrent/Registry.hs
+++ b/src/System/Metrics/Prometheus/Concurrent/Registry.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP                #-}
 module System.Metrics.Prometheus.Concurrent.Registry
        ( Registry
        , new
@@ -8,6 +9,9 @@ module System.Metrics.Prometheus.Concurrent.Registry
        ) where
 
 
+#if __GLASGOW_HASKELL__ < 710
+import Control.Applicative ((<$>))
+#endif
 import           Control.Concurrent.MVar                    (MVar,
                                                              modifyMVarMasked,
                                                              newMVar, withMVar)

--- a/src/System/Metrics/Prometheus/Concurrent/RegistryT.hs
+++ b/src/System/Metrics/Prometheus/Concurrent/RegistryT.hs
@@ -1,7 +1,12 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE CPP #-}
 
 module System.Metrics.Prometheus.Concurrent.RegistryT where
 
+#if __GLASGOW_HASKELL__ < 710
+import Control.Applicative ((<$>), Applicative)
+import           Control.Monad.Trans.Reader (runReaderT)
+#endif
 import           Control.Monad.IO.Class                        (MonadIO, liftIO)
 import           Control.Monad.Trans.Class                     (MonadTrans)
 import           Control.Monad.Trans.Reader                    (ReaderT (..),
@@ -38,5 +43,9 @@ registerHistogram :: MonadIO m => Name -> Labels -> [Histogram.UpperBound] -> Re
 registerHistogram n l b = RegistryT ask >>= liftIO . R.registerHistogram n l b
 
 
+#if __GLASGOW_HASKELL__ < 710
+sample :: (Monad m, Functor m) => RegistryT m (IO RegistrySample)
+#else
 sample :: Monad m => RegistryT m (IO RegistrySample)
+#endif
 sample = R.sample <$> RegistryT ask

--- a/src/System/Metrics/Prometheus/Encode.hs
+++ b/src/System/Metrics/Prometheus/Encode.hs
@@ -12,7 +12,7 @@ import           Data.Function                              (on)
 import           Data.List                                  (groupBy,
                                                              intersperse)
 import qualified Data.Map                                   as Map
-import           Data.Monoid                                ((<>))
+import           Data.Monoid                                ((<>), mconcat)
 
 import           System.Metrics.Prometheus.Encode.Histogram (encodeHistogram)
 import           System.Metrics.Prometheus.Encode.MetricId  (encodeDouble,

--- a/src/System/Metrics/Prometheus/Encode/Histogram.hs
+++ b/src/System/Metrics/Prometheus/Encode/Histogram.hs
@@ -8,7 +8,7 @@ module System.Metrics.Prometheus.Encode.Histogram
 import           Data.ByteString.Builder                    (Builder)
 import           Data.List                                  (intersperse)
 import qualified Data.Map                                   as Map
-import           Data.Monoid                                ((<>))
+import           Data.Monoid
 
 import           System.Metrics.Prometheus.Encode.MetricId  (encodeDouble,
                                                              encodeInt,

--- a/src/System/Metrics/Prometheus/Encode/MetricId.hs
+++ b/src/System/Metrics/Prometheus/Encode/MetricId.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE CPP #-}
 
 module System.Metrics.Prometheus.Encode.MetricId
        ( encodeHeader
@@ -16,7 +17,7 @@ module System.Metrics.Prometheus.Encode.MetricId
 import           Data.ByteString.Builder            (Builder, byteString, char8,
                                                      intDec)
 import           Data.List                          (intersperse)
-import           Data.Monoid                        ((<>))
+import           Data.Monoid
 import           Data.Text                          (Text, replace)
 import           Data.Text.Encoding                 (encodeUtf8)
 import           Data.Text.Lazy                     (toStrict)

--- a/src/System/Metrics/Prometheus/Metric/Counter.hs
+++ b/src/System/Metrics/Prometheus/Metric/Counter.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 module System.Metrics.Prometheus.Metric.Counter
        ( Counter
        , CounterSample (..)
@@ -10,6 +11,9 @@ module System.Metrics.Prometheus.Metric.Counter
 
 import           Data.Atomics.Counter (AtomicCounter, incrCounter_, newCounter,
                                        readCounter)
+#if __GLASGOW_HASKELL__ < 710
+import Control.Applicative ((<$>))
+#endif
 
 
 newtype Counter = Counter { unCounter :: AtomicCounter }

--- a/src/System/Metrics/Prometheus/Metric/Gauge.hs
+++ b/src/System/Metrics/Prometheus/Metric/Gauge.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 module System.Metrics.Prometheus.Metric.Gauge
        ( Gauge
        , GaugeSample (..)
@@ -12,6 +13,9 @@ module System.Metrics.Prometheus.Metric.Gauge
 
 import           Data.IORef (IORef, atomicModifyIORef', atomicWriteIORef,
                              newIORef, readIORef)
+#if __GLASGOW_HASKELL__ < 710
+import Control.Applicative ((<$>))
+#endif
 
 
 newtype Gauge = Gauge { unGauge :: IORef Double }

--- a/src/System/Metrics/Prometheus/Metric/Histogram.hs
+++ b/src/System/Metrics/Prometheus/Metric/Histogram.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE TupleSections #-}
+{-# LANGUAGE CPP #-}
 
 module System.Metrics.Prometheus.Metric.Histogram
        ( Histogram
@@ -15,6 +16,9 @@ import           Data.Bool  (bool)
 import           Data.IORef (IORef, atomicModifyIORef', newIORef, readIORef)
 import           Data.Map   (Map)
 import qualified Data.Map   as Map
+#if __GLASGOW_HASKELL__ < 710
+import Control.Applicative ((<$>))
+#endif
 
 
 newtype Histogram = Histogram { unHistogram :: IORef HistogramSample }

--- a/src/System/Metrics/Prometheus/MetricId.hs
+++ b/src/System/Metrics/Prometheus/MetricId.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE CPP #-}
 
 module System.Metrics.Prometheus.MetricId where
 
@@ -6,6 +7,9 @@ import           Data.Map    (Map)
 import qualified Data.Map    as Map
 import           Data.String (IsString)
 import           Data.Text   (Text)
+#if __GLASGOW_HASKELL__ < 710
+import Data.Monoid (Monoid)
+#endif
 import           Prelude     hiding (null)
 
 

--- a/src/System/Metrics/Prometheus/Registry.hs
+++ b/src/System/Metrics/Prometheus/Registry.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE OverloadedStrings  #-}
+{-# LANGUAGE CPP                #-}
 
 module System.Metrics.Prometheus.Registry
        ( Registry
@@ -11,6 +12,10 @@ module System.Metrics.Prometheus.Registry
        , sample
        ) where
 
+#if __GLASGOW_HASKELL__ < 710
+import Control.Applicative ((<$>))
+import Data.Traversable (traverse)
+#endif
 import           Control.Exception                          (Exception, throw)
 import           Data.Map                                   (Map)
 import qualified Data.Map                                   as Map
@@ -68,7 +73,7 @@ registerHistogram name labels buckets registry = do
 
 
 sample :: Registry -> IO RegistrySample
-sample = fmap RegistrySample . mapM sampleMetric . unRegistry
+sample = fmap RegistrySample . traverse sampleMetric . unRegistry
   where
     sampleMetric :: Metric -> IO MetricSample
     sampleMetric (CounterMetric count) = CounterMetricSample <$> Counter.sample count

--- a/stack-7.8.4.yaml
+++ b/stack-7.8.4.yaml
@@ -1,0 +1,19 @@
+resolver: lts-2.22
+
+packages:
+- '.'
+
+extra-deps:
+  - atomic-primops-0.8.0.4
+  - transformers-0.4.0.0
+  - wai-3.2.0
+  - warp-3.2.0
+  - http2-1.4.5
+  - hex-0.1.2
+  - psqueues-0.2.2.3
+  - auto-update-0.1.3
+  - mtl-2.2
+
+flags: {}
+
+extra-package-dbs: []


### PR DESCRIPTION
Hey @LukeHoersten !

First of all, thank you very much for this library!

Believe it or not but there are some projects here at work still bound to GHC 7.8.4, so I seized the chance to produce a clean, warning-free build for GHC 7.8.4 via deliberate use of `CPP` annotations. It builds using the newly-added `stack-7.8.4.yml` as well as the stock `stack.yml` one. Let me know what you think!

If you are not a fan of CPP we can always go to the CPP-free version, at the cost of some warnings in case `-Wall` is enabled (warnings coming mainly from the FTP & AMP proposals).

Alfredo